### PR TITLE
ci: downgrade liquibase version to 3.8.0

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -5,7 +5,7 @@ micronautVersion=2.0.0
 micronautTestVersion=1.2.0
 groovyVersion=3.0.4
 spockVersion=2.0-M3-groovy-3.0
-liquibaseVersion=3.10.1
+liquibaseVersion=3.8.0
 gormHibernateVersion=7.0.3.RELEASE
 liquibasetests=liquibase/src/test
 


### PR DESCRIPTION
`Micronaut-liquibase` 2.1.x contains 3.10.1 bump. 