### PR TITLE
bump up liquibase to 3.10.2 and update minor version 

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -5,7 +5,7 @@ micronautVersion=2.0.0
 micronautTestVersion=1.2.0
 groovyVersion=3.0.4
 spockVersion=2.0-M3-groovy-3.0
-liquibaseVersion=3.10.1
+liquibaseVersion=3.8.0
 gormHibernateVersion=7.0.3.RELEASE
 liquibasetests=liquibase/src/test
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -15,7 +15,7 @@ projectUrl=http://micronaut.io
 githubSlug=micronaut-projects/micronaut-liquibase
 developers=Ivan Lopez
 
-githubBranch=master
+githubBranch=2.0.x
 githubCoreBranch=2.0.x
 bomProperty=micronautLiquibaseVersion
 bomProperties=liquibaseVersion

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-projectVersion=2.0.2.BUILD-SNAPSHOT
+projectVersion=2.1.0.BUILD-SNAPSHOT
 micronautDocsVersion=1.0.24
 micronautBuildVersion=1.0.0
 micronautVersion=2.0.0

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-projectVersion=2.0.1
+projectVersion=2.0.2.BUILD-SNAPSHOT
 micronautDocsVersion=1.0.24
 micronautBuildVersion=1.0.0
 micronautVersion=2.0.0

--- a/gradle.properties
+++ b/gradle.properties
@@ -15,8 +15,8 @@ projectUrl=http://micronaut.io
 githubSlug=micronaut-projects/micronaut-liquibase
 developers=Ivan Lopez
 
-githubCoreBranch=2.0.x
 githubBranch=master
+githubCoreBranch=2.1.x
 bomProperty=micronautLiquibaseVersion
 bomProperties=liquibaseVersion
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -5,7 +5,7 @@ micronautVersion=2.0.0
 micronautTestVersion=1.2.0
 groovyVersion=3.0.4
 spockVersion=2.0-M3-groovy-3.0
-liquibaseVersion=3.8.0
+liquibaseVersion=3.10.2
 gormHibernateVersion=7.0.3.RELEASE
 liquibasetests=liquibase/src/test
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -16,7 +16,7 @@ githubSlug=micronaut-projects/micronaut-liquibase
 developers=Ivan Lopez
 
 githubBranch=master
-githubCoreBranch=master
+githubCoreBranch=2.0.x
 bomProperty=micronautLiquibaseVersion
 bomProperties=liquibaseVersion
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -15,8 +15,8 @@ projectUrl=http://micronaut.io
 githubSlug=micronaut-projects/micronaut-liquibase
 developers=Ivan Lopez
 
-githubBranch=2.0.x
 githubCoreBranch=2.0.x
+githubBranch=master
 bomProperty=micronautLiquibaseVersion
 bomProperties=liquibaseVersion
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-projectVersion=2.0.1.BUILD-SNAPSHOT
+projectVersion=2.0.1
 micronautDocsVersion=1.0.24
 micronautBuildVersion=1.0.0
 micronautVersion=2.0.0

--- a/src/main/docs/guide/releaseHistory.adoc
+++ b/src/main/docs/guide/releaseHistory.adoc
@@ -1,0 +1,3 @@
+For this project, you can find a list of releases (with release notes) here:
+
+https://github.com/{githubSlug}/releases[https://github.com/{githubSlug}/releases]

--- a/src/main/docs/guide/toc.yml
+++ b/src/main/docs/guide/toc.yml
@@ -1,5 +1,5 @@
-introduction:
-  title: Introduction
+introduction: Introduction
+releaseHistory: Release History
 whatsNew: What's New
 configuration: Configuration
 gorm: GORM Support


### PR DESCRIPTION
- set project version to 2.1.0.BUILD-SNAPSHOT
- set github core branch to 2.1.x
- set github branch to master
- build: set liquibase version to 3.10.2

Liquibase release notes:

- [3.10.2](https://github.com/liquibase/liquibase/releases/tag/v3.10.2)
- [3.10.1](https://github.com/liquibase/liquibase/releases/tag/v3.10.1)
- [3.10.0](https://github.com/liquibase/liquibase/releases/tag/v3.10.0)
- [3.9.0](https://github.com/liquibase/liquibase/releases/tag/v3.9.0)
- [3.8.9](https://github.com/liquibase/liquibase/releases/tag/v3.8.9)
- [3.8.8](https://github.com/liquibase/liquibase/releases/tag/v3.8.8)
- [3.8.6](https://github.com/liquibase/liquibase/releases/tag/v3.8.6)
- [3.8.5](https://github.com/liquibase/liquibase/releases/tag/v3.8.5)
- [3.8.4](https://github.com/liquibase/liquibase/releases/tag/v3.8.4)
- [3.8.3](https://github.com/liquibase/liquibase/releases/tag/v3.8.3)
- [3.8.2](https://github.com/liquibase/liquibase/releases/tag/v3.8.2)
- [3.8.1](https://github.com/liquibase/liquibase/releases/tag/v3.8.1)