### PR TITLE
build: Move to using our latest build infrastructure

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,14 +1,10 @@
 projectVersion=5.3.0-SNAPSHOT
 projectGroup=io.micronaut.liquibase
-micronautDocsVersion=2.0.0
 micronautVersion=3.3.4
 micronautTestVersion=3.0.5
 
 groovyVersion=3.0.10
 spockVersion=2.0-groovy-3.0
-
-liquibaseVersion=4.9.1
-gormHibernateVersion=7.2.2
 
 title=Micronaut Liquibase
 projectDesc=Integration between Micronaut and Liquibase

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,6 +2,7 @@ projectVersion=5.3.0-SNAPSHOT
 projectGroup=io.micronaut.liquibase
 micronautVersion=3.3.4
 micronautTestVersion=3.0.5
+micronautDocsVersion=2.0.0
 
 groovyVersion=3.0.10
 spockVersion=2.0-groovy-3.0

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,0 +1,28 @@
+[versions]
+managed-liquibase = "4.9.1"
+
+micronaut-docs = "2.0.0"
+
+gorm-hibernate = "7.2.2"
+persistence-api = '2.2'
+
+[libraries]
+managed-liquibase = { module = "org.liquibase:liquibase-core", version.ref = "managed-liquibase" }
+
+micronaut-docs = { module = "io.micronaut.docs:micronaut-docs-asciidoc-config-props", version.ref = "micronaut-docs" }
+micronaut-hibernate-gorm = { module = "io.micronaut.groovy:micronaut-hibernate-gorm" }
+micronaut-http-client = { module = "io.micronaut:micronaut-http-client" }
+micronaut-http-server-netty = { module = "io.micronaut:micronaut-http-server-netty" }
+micronaut-inject-java = { module = 'io.micronaut:micronaut-inject-java' }
+micronaut-jdbc = { module = "io.micronaut.sql:micronaut-jdbc" }
+micronaut-jdbc-hikari = { module = "io.micronaut.sql:micronaut-jdbc-hikari" }
+micronaut-management = { module = "io.micronaut:micronaut-management" }
+
+grails-datastore-gorm-hibernate5 = { module = "org.grails:grails-datastore-gorm-hibernate5", version.ref = "gorm-hibernate" }
+
+groovy-sql = { module = "org.codehaus.groovy:groovy-sql" }
+
+h2 = { module = "com.h2database:h2" }
+
+persistence-api = { module = 'javax.persistence:javax.persistence-api', version.ref = 'persistence-api'}
+projectreactor = { module = 'io.projectreactor:reactor-core' }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,15 +1,12 @@
 [versions]
 managed-liquibase = "4.9.1"
 
-micronaut-docs = "2.0.0"
-
 gorm-hibernate = "7.2.2"
 persistence-api = '2.2'
 
 [libraries]
 managed-liquibase = { module = "org.liquibase:liquibase-core", version.ref = "managed-liquibase" }
 
-micronaut-docs = { module = "io.micronaut.docs:micronaut-docs-asciidoc-config-props", version.ref = "micronaut-docs" }
 micronaut-hibernate-gorm = { module = "io.micronaut.groovy:micronaut-hibernate-gorm" }
 micronaut-http-client = { module = "io.micronaut:micronaut-http-client" }
 micronaut-http-server-netty = { module = "io.micronaut:micronaut-http-server-netty" }

--- a/liquibase-bom/build.gradle
+++ b/liquibase-bom/build.gradle
@@ -1,8 +1,3 @@
 plugins {
     id "io.micronaut.build.internal.bom"
 }
-dependencies {
-    constraints {
-        api ("org.liquibase:liquibase-core:$liquibaseVersion")
-    }
-}

--- a/liquibase/build.gradle
+++ b/liquibase/build.gradle
@@ -4,7 +4,6 @@ plugins {
 
 dependencies {
     annotationProcessor libs.micronaut.inject.java
-    annotationProcessor libs.micronaut.docs
 
     compileOnly libs.micronaut.inject.java
     compileOnly libs.grails.datastore.gorm.hibernate5

--- a/liquibase/build.gradle
+++ b/liquibase/build.gradle
@@ -3,32 +3,29 @@ plugins {
 }
 
 dependencies {
-    annotationProcessor "io.micronaut:micronaut-inject-java"
-    annotationProcessor "io.micronaut.docs:micronaut-docs-asciidoc-config-props:$micronautDocsVersion"
+    annotationProcessor libs.micronaut.inject.java
+    annotationProcessor libs.micronaut.docs
 
-    compileOnly "io.micronaut:micronaut-inject-java"
-    compileOnly "org.grails:grails-datastore-gorm-hibernate5:$gormHibernateVersion"
+    compileOnly libs.micronaut.inject.java
+    compileOnly libs.grails.datastore.gorm.hibernate5
 
-    api ("org.liquibase:liquibase-core:$liquibaseVersion") {
+    api (libs.managed.liquibase) {
         exclude group: 'org.springframework'
     }
-    api "io.micronaut:micronaut-management"
-    api "io.micronaut.sql:micronaut-jdbc"
-    implementation "io.projectreactor:reactor-core"
-    implementation 'jakarta.inject:jakarta.inject-api:2.0.1'
+    api libs.micronaut.management
+    api libs.micronaut.jdbc
 
-    testAnnotationProcessor "org.codehaus.groovy:groovy-sql:$groovyVersion"
-    testAnnotationProcessor "javax.persistence:javax.persistence-api:2.2"
+    implementation libs.projectreactor
 
-    testImplementation("org.spockframework:spock-core:${spockVersion}") {
-        exclude module:'groovy-all'
-    }
-    testImplementation "io.micronaut:micronaut-inject-java"
-    testImplementation "io.micronaut:micronaut-http-client"
-    testImplementation "io.micronaut:micronaut-http-server-netty"
-    testImplementation "io.micronaut.sql:micronaut-jdbc-hikari"
-    testImplementation "io.micronaut.groovy:micronaut-hibernate-gorm"
-    testImplementation "org.codehaus.groovy:groovy-sql"
-    testImplementation "org.grails:grails-datastore-gorm-hibernate5:$gormHibernateVersion"
-    testImplementation "com.h2database:h2"
+    testAnnotationProcessor libs.groovy.sql
+    testAnnotationProcessor libs.persistence.api
+
+    testImplementation libs.micronaut.inject.java
+    testImplementation libs.micronaut.http.client
+    testImplementation libs.micronaut.http.server.netty
+    testImplementation libs.micronaut.jdbc.hikari
+    testImplementation libs.micronaut.hibernate.gorm
+    testImplementation libs.groovy.sql
+    testImplementation libs.grails.datastore.gorm.hibernate5
+    testImplementation libs.h2
 }

--- a/liquibase/build.gradle
+++ b/liquibase/build.gradle
@@ -3,8 +3,6 @@ plugins {
 }
 
 dependencies {
-    annotationProcessor libs.micronaut.inject.java
-
     compileOnly libs.micronaut.inject.java
     compileOnly libs.grails.datastore.gorm.hibernate5
 


### PR DESCRIPTION
This moves to using managed versions and a library catalog, this means that we get the managed liquibase version in our catalog toml file exported by the bom.

This is the only change, no other dependencies have changed, so I believe this can go out as a patch release.

Fixes #261 