### PR TITLE
Make migration runner classes public

### DIFF
--- a/liquibase/src/main/java/io/micronaut/liquibase/GormMigrationRunner.java
+++ b/liquibase/src/main/java/io/micronaut/liquibase/GormMigrationRunner.java
@@ -36,7 +36,7 @@ import javax.sql.DataSource;
 @Singleton
 @Requires(classes = {HibernateDatastore.class})
 @Requires(property = "data-source")
-class GormMigrationRunner extends AbstractLiquibaseMigration implements BeanCreatedEventListener<HibernateDatastore> {
+public class GormMigrationRunner extends AbstractLiquibaseMigration implements BeanCreatedEventListener<HibernateDatastore> {
 
     /**
      * @param applicationContext The application context

--- a/liquibase/src/main/java/io/micronaut/liquibase/LiquibaseMigrationRunner.java
+++ b/liquibase/src/main/java/io/micronaut/liquibase/LiquibaseMigrationRunner.java
@@ -60,7 +60,7 @@ import java.util.Map;
  * @since 1.0.0
  */
 @Singleton
-class LiquibaseMigrationRunner extends AbstractLiquibaseMigration implements BeanCreatedEventListener<DataSource> {
+public class LiquibaseMigrationRunner extends AbstractLiquibaseMigration implements BeanCreatedEventListener<DataSource> {
 
     private static final Logger LOG = LoggerFactory.getLogger(LiquibaseMigrationRunner.class);
 


### PR DESCRIPTION
So that it can be replaced