### PR TITLE
Stop pulling serde in to the classpath when using liquibase

### DIFF
--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -1,0 +1,12 @@
+plugins {
+    id "groovy-gradle-plugin"
+}
+
+repositories {
+    mavenCentral()
+    gradlePluginPortal()
+}
+
+dependencies {
+    implementation libs.gradle.micronaut
+}

--- a/buildSrc/settings.gradle
+++ b/buildSrc/settings.gradle
@@ -1,0 +1,7 @@
+dependencyResolutionManagement {
+    versionCatalogs {
+        libs {
+            from(files("../gradle/libs.versions.toml"))
+        }
+    }
+}

--- a/buildSrc/src/main/groovy/io.micronaut.build.internal.liquibase.test-suite-module.gradle
+++ b/buildSrc/src/main/groovy/io.micronaut.build.internal.liquibase.test-suite-module.gradle
@@ -1,0 +1,32 @@
+plugins {
+    id("groovy")
+    id("io.micronaut.library")
+}
+
+repositories {
+    mavenCentral()
+}
+
+dependencies {
+    testImplementation(project(":liquibase"))
+
+    testImplementation("io.micronaut:micronaut-http-validation")
+    testImplementation("io.micronaut:micronaut-http-client")
+
+    testImplementation("io.micronaut.sql:micronaut-jdbc-hikari")
+    testImplementation("io.micronaut:micronaut-http-server-netty")
+    testImplementation("io.micronaut.groovy:micronaut-runtime-groovy")
+    testImplementation("io.micronaut:micronaut-validation")
+
+    testRuntimeOnly("ch.qos.logback:logback-classic")
+    testRuntimeOnly("com.h2database:h2")
+}
+
+micronaut {
+    runtime("netty")
+    testRuntime("spock2")
+    processing {
+        incremental(true)
+        annotations("com.example.*")
+    }
+}

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-projectVersion=5.6.0
+projectVersion=5.6.1-SNAPSHOT
 projectGroup=io.micronaut.liquibase
 micronautVersion=3.7.5
 micronautTestVersion=3.8.0

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -4,6 +4,8 @@ managed-liquibase = "4.18.0"
 gorm-hibernate = "7.3.0"
 persistence-api = '2.2'
 
+micronaut-gradle-plugin = "3.7.4"
+
 [libraries]
 managed-liquibase = { module = "org.liquibase:liquibase-core", version.ref = "managed-liquibase" }
 
@@ -26,3 +28,5 @@ h2 = { module = "com.h2database:h2" }
 
 persistence-api = { module = 'javax.persistence:javax.persistence-api', version.ref = 'persistence-api'}
 projectreactor = { module = 'io.projectreactor:reactor-core' }
+
+gradle-micronaut = { module = "io.micronaut.gradle:micronaut-gradle-plugin", version.ref = "micronaut-gradle-plugin" }

--- a/liquibase/build.gradle
+++ b/liquibase/build.gradle
@@ -6,15 +6,14 @@ dependencies {
     annotationProcessor(libs.micronaut.serde.processor)
     compileOnly libs.micronaut.inject.java
     compileOnly libs.grails.datastore.gorm.hibernate5
+    compileOnly(libs.micronaut.serde.api)
+    compileOnly(libs.micronaut.serde.jackson)
 
     api (libs.managed.liquibase) {
         exclude group: 'org.springframework'
     }
     api libs.micronaut.management
     api libs.micronaut.jdbc
-
-    implementation libs.micronaut.serde.api
-    implementation libs.micronaut.serde.jackson
 
     implementation libs.projectreactor
 
@@ -29,4 +28,5 @@ dependencies {
     testImplementation libs.groovy.sql
     testImplementation libs.grails.datastore.gorm.hibernate5
     testImplementation libs.h2
+    testImplementation(libs.micronaut.serde.jackson)
 }

--- a/settings.gradle
+++ b/settings.gradle
@@ -14,4 +14,5 @@ rootProject.name = 'liquibase-parent'
 include 'liquibase'
 include 'liquibase-bom'
 
+include 'test-suite-jackson'
 include 'test-suite-serde'

--- a/test-suite-jackson/build.gradle.kts
+++ b/test-suite-jackson/build.gradle.kts
@@ -5,6 +5,5 @@ plugins {
 description = "Test suite for Liquibase + Jackson"
 
 dependencies {
-    testImplementation("io.micronaut.serde:micronaut-serde-api")
-    testImplementation("io.micronaut.serde:micronaut-serde-jackson")
+    testImplementation("io.micronaut:micronaut-jackson-databind")
 }

--- a/test-suite-jackson/src/test/groovy/io/micronaut/liquibase/Dto.groovy
+++ b/test-suite-jackson/src/test/groovy/io/micronaut/liquibase/Dto.groovy
@@ -1,0 +1,6 @@
+package io.micronaut.liquibase
+
+class Dto {
+
+    String name
+}

--- a/test-suite-jackson/src/test/groovy/io/micronaut/liquibase/JacksonEndpointSpec.groovy
+++ b/test-suite-jackson/src/test/groovy/io/micronaut/liquibase/JacksonEndpointSpec.groovy
@@ -11,7 +11,7 @@ import jakarta.inject.Inject
 import spock.lang.Specification
 
 @MicronautTest
-class SerdeEndpointSpec extends Specification {
+class JacksonEndpointSpec extends Specification {
 
     @Inject
     @Client("/")

--- a/test-suite-jackson/src/test/groovy/io/micronaut/liquibase/MyController.groovy
+++ b/test-suite-jackson/src/test/groovy/io/micronaut/liquibase/MyController.groovy
@@ -1,0 +1,13 @@
+package io.micronaut.liquibase
+
+import io.micronaut.http.annotation.Controller
+import io.micronaut.http.annotation.Post
+
+@Controller
+class MyController {
+
+    @Post
+    String index(Dto dto) {
+        "Hello $dto.name"
+    }
+}

--- a/test-suite-jackson/src/test/resources/application.yml
+++ b/test-suite-jackson/src/test/resources/application.yml
@@ -1,0 +1,13 @@
+endpoints:
+  liquibase:
+    sensitive: false
+datasources:
+  default:
+    url: jdbc:h2:mem:liquibaseEndpointDb;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=TRUE
+    username: 'sa'
+    password: ''
+    driver-class-name: 'org.h2.Driver'
+liquibase:
+  datasources:
+    default:
+      change-log: classpath:db/liquibase-changelog.xml

--- a/test-suite-jackson/src/test/resources/db/changelog/01-create-books-schema.xml
+++ b/test-suite-jackson/src/test/resources/db/changelog/01-create-books-schema.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<databaseChangeLog
+  xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+         http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
+  <changeSet id="01" author="sdelamo">
+    <createTable tableName="books"
+      remarks="A table to contain all books">
+      <column name="id" type="int">
+        <constraints nullable="false" unique="true" primaryKey="true"/>
+      </column>
+      <column name="name" type="varchar(255)">
+        <constraints nullable="false" unique="true"/>
+      </column>
+    </createTable>
+  </changeSet>
+</databaseChangeLog>

--- a/test-suite-jackson/src/test/resources/db/changelog/01b-create-books-schema.xml
+++ b/test-suite-jackson/src/test/resources/db/changelog/01b-create-books-schema.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<databaseChangeLog
+  xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+         http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
+  <changeSet id="01" author="sdelamo">
+    <createTable tableName="books"
+      remarks="A table to contain all books">
+      <column name="id" type="int">
+        <constraints nullable="false" unique="true" primaryKey="true"/>
+      </column>
+      <column name="name" type="varchar(255)">
+        <constraints nullable="false" unique="true"/>
+      </column>
+    </createTable>
+  </changeSet>
+</databaseChangeLog>

--- a/test-suite-jackson/src/test/resources/db/changelog/02-insert-data-books.xml
+++ b/test-suite-jackson/src/test/resources/db/changelog/02-insert-data-books.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<databaseChangeLog
+  xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+         http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
+  <changeSet id="02" author="sdelamo">
+    <comment>Inserting Books</comment>
+    <insert tableName="books">
+      <column name="id" valueNumeric="1"/>
+      <column name="name" value="Building Microservice"/>
+    </insert>
+    <insert tableName="books">
+      <column name="id" valueNumeric="2"/>
+      <column name="name" value="Release it"/>
+    </insert>
+  </changeSet>
+</databaseChangeLog>

--- a/test-suite-jackson/src/test/resources/db/changelog/03-create-books-schema.xml
+++ b/test-suite-jackson/src/test/resources/db/changelog/03-create-books-schema.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<databaseChangeLog
+  xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+         http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
+  <changeSet id="01" author="sdelamo">
+    <createTable tableName="books"
+      remarks="A table to contain all books">
+      <column name="id" type="int">
+        <constraints nullable="false" unique="true" primaryKey="true"/>
+      </column>
+      <column name="name" type="varchar(255)">
+        <constraints nullable="false" unique="true"/>
+      </column>
+    </createTable>
+  </changeSet>
+</databaseChangeLog>

--- a/test-suite-jackson/src/test/resources/db/liquibase-changelog.xml
+++ b/test-suite-jackson/src/test/resources/db/liquibase-changelog.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+  xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+         http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
+  <include file="changelog/01-create-books-schema.xml" relativeToChangelogFile="true"/>
+  <include file="changelog/02-insert-data-books.xml" relativeToChangelogFile="true"/>
+</databaseChangeLog>

--- a/test-suite-jackson/src/test/resources/logback.xml
+++ b/test-suite-jackson/src/test/resources/logback.xml
@@ -1,0 +1,14 @@
+<configuration>
+
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <!-- encoders are assigned the type
+             ch.qos.logback.classic.encoder.PatternLayoutEncoder by default -->
+        <encoder>
+            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <root level="error">
+        <appender-ref ref="STDOUT" />
+    </root>
+</configuration>

--- a/test-suite-serde/src/test/groovy/io/micronaut/liquibase/Dto.groovy
+++ b/test-suite-serde/src/test/groovy/io/micronaut/liquibase/Dto.groovy
@@ -1,0 +1,9 @@
+package io.micronaut.liquibase
+
+import io.micronaut.serde.annotation.Serdeable
+
+@Serdeable
+class Dto {
+
+    String name
+}

--- a/test-suite-serde/src/test/groovy/io/micronaut/liquibase/MyController.groovy
+++ b/test-suite-serde/src/test/groovy/io/micronaut/liquibase/MyController.groovy
@@ -1,0 +1,13 @@
+package io.micronaut.liquibase
+
+import io.micronaut.http.annotation.Controller
+import io.micronaut.http.annotation.Post
+
+@Controller
+class MyController {
+
+    @Post
+    String index(Dto dto) {
+        "Hello $dto.name"
+    }
+}

--- a/test-suite-serde/src/test/resources/application.yml
+++ b/test-suite-serde/src/test/resources/application.yml
@@ -1,0 +1,13 @@
+endpoints:
+  liquibase:
+    sensitive: false
+datasources:
+  default:
+    url: jdbc:h2:mem:liquibaseEndpointDb;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=TRUE
+    username: 'sa'
+    password: ''
+    driver-class-name: 'org.h2.Driver'
+liquibase:
+  datasources:
+    default:
+      change-log: classpath:db/liquibase-changelog.xml


### PR DESCRIPTION
Adds a test for jackson and changes the serde test to be similar

Closes #341 and #342

Also had to fix gradle-properties as they hadn't been put back to the next version.

Targets 5.6.1 as the issue was introduced in 5.6.x