### PR TITLE
Fix native tests

### DIFF
--- a/test-suite-graal-mariadb/build.gradle.kts
+++ b/test-suite-graal-mariadb/build.gradle.kts
@@ -4,5 +4,7 @@ plugins {
 
 dependencies {
     runtimeOnly(mnSql.mariadb.java.client)
-    implementation(mnTestResources.micronaut.test.resources.extensions.junit.platform)
+    testImplementation(mnTestResources.micronaut.test.resources.extensions.junit.platform) {
+        exclude(group = "org.jetbrains.kotlin")
+    }
 }

--- a/test-suite-graal-postgres/build.gradle.kts
+++ b/test-suite-graal-postgres/build.gradle.kts
@@ -4,5 +4,7 @@ plugins {
 
 dependencies {
     runtimeOnly(mnSql.postgresql)
-    implementation(mnTestResources.micronaut.test.resources.extensions.junit.platform)
+    implementation(mnTestResources.micronaut.test.resources.extensions.junit.platform) {
+        exclude(group = "org.jetbrains.kotlin")
+    }
 }


### PR DESCRIPTION
Exclude kotlin from `mnTestResources.micronaut.test.resources.extensions.junit.platform`.

When we use this dependency, we pull in kotlin, and we end up with native errors as CoroutineSingletons get initialised at build time.

@melix I don't see why this is required on master, but not on the `6.1.x` branch...  Do you?