### PR TITLE
fix: migrations not triggered for manual datasources

### DIFF
--- a/liquibase/src/main/java/io/micronaut/liquibase/LiquibaseMigrationRunner.java
+++ b/liquibase/src/main/java/io/micronaut/liquibase/LiquibaseMigrationRunner.java
@@ -19,7 +19,6 @@ import io.micronaut.context.ApplicationContext;
 import io.micronaut.context.event.BeanCreatedEvent;
 import io.micronaut.context.event.BeanCreatedEventListener;
 import io.micronaut.core.annotation.Nullable;
-import io.micronaut.core.naming.NameResolver;
 import io.micronaut.inject.qualifiers.Qualifiers;
 import io.micronaut.jdbc.DataSourceResolver;
 import io.micronaut.scheduling.TaskExecutors;
@@ -56,15 +55,17 @@ class LiquibaseMigrationRunner extends AbstractLiquibaseMigration implements Bea
     @Override
     public DataSource onCreated(BeanCreatedEvent<DataSource> event) {
         DataSource dataSource = event.getBean();
-        if (event.getBeanDefinition() instanceof NameResolver) {
-            ((NameResolver) event.getBeanDefinition())
-                    .resolveName().flatMap(name -> applicationContext
-                            .findBean(LiquibaseConfigurationProperties.class, Qualifiers.byName(name))).ifPresent(cfg -> {
-                        DataSource unwrappedDataSource = dataSourceResolver.resolve(dataSource);
-                        run(cfg, unwrappedDataSource);
-                    });
-        }
+        event.getBeanDefinition().getBeanName()
+                .ifPresent(name -> runMigration(name, dataSource));
         return dataSource;
+    }
+
+    private void runMigration(String name, DataSource dataSource) {
+        applicationContext.findBean(LiquibaseConfigurationProperties.class, Qualifiers.byName(name))
+                .ifPresent(cfg -> {
+                    DataSource unwrappedDataSource = dataSourceResolver.resolve(dataSource);
+                    run(cfg, unwrappedDataSource);
+                });
     }
 
     /**

--- a/settings.gradle
+++ b/settings.gradle
@@ -16,6 +16,7 @@ include 'liquibase-bom'
 
 include 'test-suite-jackson'
 include 'test-suite-serde'
+include 'test-suite-manual-datasource'
 include 'test-suite-graal-h2'
 include 'test-suite-graal'
 include 'test-suite-graal-mariadb'

--- a/test-suite-manual-datasource/build.gradle.kts
+++ b/test-suite-manual-datasource/build.gradle.kts
@@ -1,0 +1,27 @@
+plugins {
+    id("io.micronaut.build.internal.liquibase-base")
+    `java-library`
+}
+
+description = "Test suite for Liquibase + Manual DataSource Configuration"
+
+dependencies {
+    annotationProcessor(mn.micronaut.inject.java)
+    annotationProcessor(mnData.micronaut.data.processor)
+    implementation(mnData.micronaut.data.jdbc)
+    implementation(mn.micronaut.http.server.netty)
+    implementation(projects.micronautLiquibase)
+    implementation(mnSql.hikaricp)
+    annotationProcessor(mnSerde.micronaut.serde.processor)
+    implementation(mnSerde.micronaut.serde.jackson)
+    runtimeOnly(mnLogging.logback.classic)
+    runtimeOnly(mnSql.h2)
+
+    testAnnotationProcessor(mn.micronaut.inject.java)
+    testImplementation(mnTest.micronaut.test.junit5)
+    testImplementation(mn.micronaut.http.client)
+    testRuntimeOnly(mnTest.junit.jupiter.engine)
+}
+tasks.withType<Test> {
+    useJUnitPlatform()
+}

--- a/test-suite-manual-datasource/src/main/java/example/micronaut/Book.java
+++ b/test-suite-manual-datasource/src/main/java/example/micronaut/Book.java
@@ -1,0 +1,16 @@
+package example.micronaut;
+
+import io.micronaut.data.annotation.GeneratedValue;
+import io.micronaut.data.annotation.Id;
+import io.micronaut.data.annotation.MappedEntity;
+import io.micronaut.serde.annotation.Serdeable;
+
+@Serdeable
+@MappedEntity
+public record Book(
+    @GeneratedValue
+    @Id Long id,
+    String title
+) {
+
+}

--- a/test-suite-manual-datasource/src/main/java/example/micronaut/BookController.java
+++ b/test-suite-manual-datasource/src/main/java/example/micronaut/BookController.java
@@ -1,0 +1,37 @@
+package example.micronaut;
+
+import io.micronaut.http.annotation.Controller;
+import io.micronaut.http.annotation.Get;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Controller("/books")
+class BookController {
+    private final MicronautBookRepository micronautBookRepository;
+    private final GrailsBookRepository grailsBookRepository;
+
+    BookController(MicronautBookRepository micronautBookRepository,
+                   GrailsBookRepository grailsBookRepository) {
+        this.micronautBookRepository = micronautBookRepository;
+        this.grailsBookRepository = grailsBookRepository;
+    }
+
+    @Get
+    List<Book> all() {
+        List<Book> all = new ArrayList<>();
+        all.addAll(micronaut());
+        all.addAll(grails());
+        return all;
+    }
+
+    @Get("/micronaut")
+    List<Book> micronaut() {
+        return micronautBookRepository.findAll();
+    }
+
+    @Get("/grails")
+    List<Book> grails() {
+        return grailsBookRepository.findAll();
+    }
+}

--- a/test-suite-manual-datasource/src/main/java/example/micronaut/BookRepository.java
+++ b/test-suite-manual-datasource/src/main/java/example/micronaut/BookRepository.java
@@ -1,0 +1,6 @@
+package example.micronaut;
+
+import io.micronaut.data.repository.CrudRepository;
+
+public interface BookRepository extends CrudRepository<Book, Long> {
+}

--- a/test-suite-manual-datasource/src/main/java/example/micronaut/DatasourceFactory.java
+++ b/test-suite-manual-datasource/src/main/java/example/micronaut/DatasourceFactory.java
@@ -1,0 +1,37 @@
+package example.micronaut;
+
+import com.zaxxer.hikari.HikariDataSource;
+import io.micronaut.context.annotation.Factory;
+import io.micronaut.context.annotation.Primary;
+import jakarta.inject.Named;
+import jakarta.inject.Singleton;
+
+import javax.sql.DataSource;
+
+
+@Factory
+public class DatasourceFactory {
+
+    @Singleton
+    @Primary
+    @Named("default")
+    DataSource dataSource() {
+        HikariDataSource ds = new HikariDataSource();
+        ds.setJdbcUrl("jdbc:h2:mem:micronautDb;LOCK_TIMEOUT=10000;DB_CLOSE_ON_EXIT=FALSE");
+        ds.setUsername("sa");
+        ds.setPassword("");
+        ds.setDriverClassName("org.h2.Driver");
+        return ds;
+    }
+
+    @Singleton
+    @Named("grails")
+    DataSource dataSourceGrails() {
+        HikariDataSource ds = new HikariDataSource();
+        ds.setJdbcUrl("jdbc:h2:mem:grailsDb;LOCK_TIMEOUT=10000;DB_CLOSE_ON_EXIT=FALSE");
+        ds.setUsername("sa");
+        ds.setPassword("");
+        ds.setDriverClassName("org.h2.Driver");
+        return ds;
+    }
+}

--- a/test-suite-manual-datasource/src/main/java/example/micronaut/GrailsBookRepository.java
+++ b/test-suite-manual-datasource/src/main/java/example/micronaut/GrailsBookRepository.java
@@ -1,0 +1,8 @@
+package example.micronaut;
+
+import io.micronaut.data.jdbc.annotation.JdbcRepository;
+import io.micronaut.data.model.query.builder.sql.Dialect;
+
+@JdbcRepository(dialect = Dialect.H2, dataSource = "grails")
+public interface GrailsBookRepository extends BookRepository {
+}

--- a/test-suite-manual-datasource/src/main/java/example/micronaut/MicronautBookRepository.java
+++ b/test-suite-manual-datasource/src/main/java/example/micronaut/MicronautBookRepository.java
@@ -1,0 +1,8 @@
+package example.micronaut;
+
+import io.micronaut.data.jdbc.annotation.JdbcRepository;
+import io.micronaut.data.model.query.builder.sql.Dialect;
+
+@JdbcRepository(dialect = Dialect.H2)
+public interface MicronautBookRepository extends BookRepository{
+}

--- a/test-suite-manual-datasource/src/main/resources/application.properties
+++ b/test-suite-manual-datasource/src/main/resources/application.properties
@@ -1,0 +1,9 @@
+# Micronaut Books DataSource
+datasources.default.dialect=H2
+datasources.default.schema-generate=NONE
+liquibase.datasources.default.change-log=classpath\:db/liquibase-changelog.xml
+
+# Grails Books DataSource
+datasources.grails.dialect=H2
+datasources.grails.schema-generate=NONE
+liquibase.datasources.grails.change-log=classpath\:db/liquibase-changelog.xml

--- a/test-suite-manual-datasource/src/main/resources/db/changelog/01-schema.xml
+++ b/test-suite-manual-datasource/src/main/resources/db/changelog/01-schema.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
+
+    <changeSet id="01" author="username">
+        <createTable tableName="book">
+            <column name="id" type="BIGINT" autoIncrement="true">
+                <constraints primaryKey="true" nullable="false"/>
+            </column>
+            <column name="title" type="VARCHAR(255)">
+                <constraints nullable="false"/>
+            </column>
+        </createTable>
+    </changeSet>
+
+</databaseChangeLog>

--- a/test-suite-manual-datasource/src/main/resources/db/liquibase-changelog.xml
+++ b/test-suite-manual-datasource/src/main/resources/db/liquibase-changelog.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
+        <include file="changelog/01-schema.xml" relativeToChangelogFile="true"/>
+</databaseChangeLog>

--- a/test-suite-manual-datasource/src/main/resources/logback.xml
+++ b/test-suite-manual-datasource/src/main/resources/logback.xml
@@ -1,0 +1,10 @@
+<configuration>
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+        </encoder>
+    </appender>
+    <root level="error">
+        <appender-ref ref="STDOUT" />
+    </root>
+</configuration>

--- a/test-suite-manual-datasource/src/test/java/example/micronaut/BookControllerTest.java
+++ b/test-suite-manual-datasource/src/test/java/example/micronaut/BookControllerTest.java
@@ -1,0 +1,72 @@
+package example.micronaut;
+
+import io.micronaut.core.type.Argument;
+import io.micronaut.http.HttpRequest;
+import io.micronaut.http.client.BlockingHttpClient;
+import io.micronaut.http.client.HttpClient;
+import io.micronaut.http.client.annotation.Client;
+import io.micronaut.test.extensions.junit5.annotation.MicronautTest;
+import jakarta.inject.Inject;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@MicronautTest(transactional = false)
+class BookControllerTest {
+
+    @Inject
+    MicronautBookRepository micronautBookRepository;
+
+    @Inject
+    GrailsBookRepository grailsBookRepository;
+
+    @Inject
+    @Client("/")
+    HttpClient httpClient;
+
+    @Test
+    void books() {
+        //given:
+        saveGrailsBooks();
+        saveMicronautBooks();
+
+        BlockingHttpClient client = httpClient.toBlocking();
+        Argument<List<Book>> arg = Argument.listOf(Book.class);
+
+        //when:
+        List<Book> books = client.retrieve(HttpRequest.GET("/books"), arg);
+        //then:
+        assertEquals(9, books.size());
+
+        //when:
+        books = client.retrieve(HttpRequest.GET("/books/micronaut"), arg);
+        //then:
+        assertEquals(2, books.size());
+
+        //when:
+        books = client.retrieve(HttpRequest.GET("/books/grails"), arg);
+
+        //then:
+        assertEquals(7, books.size());
+        //cleanup:
+        grailsBookRepository.deleteAll();
+        micronautBookRepository.deleteAll();
+    }
+
+    void saveGrailsBooks() {
+        grailsBookRepository.save(new Book(null, "Grails 3 - Step by Step"));
+        grailsBookRepository.save(new Book(null, "Grails Goodness Notebook"));
+        grailsBookRepository.save(new Book(null, "Falando de Grails"));
+        grailsBookRepository.save(new Book(null, "Grails in Action"));
+        grailsBookRepository.save(new Book(null, "The Definitive Guide to Grails 2"));
+        grailsBookRepository.save(new Book(null, "Programming Grails"));
+        grailsBookRepository.save(new Book(null, "Grails 2: Quick Start Guide"));
+    }
+
+    void saveMicronautBooks() {
+        micronautBookRepository.save(new Book(null, "Introducing Micronaut: Build, Test and Deploy Java Microservices on Oracle Cloud"));
+        micronautBookRepository.save(new Book(null, "Building Microservices wiht Micronaut: A quick-start guide to building high-performance reactive microservices for Java developers"));
+    }
+}


### PR DESCRIPTION
I changed to use `event.getBeanDefinition().getBeanName()` instead of

```java
event.getBeanDefinition() instanceof NameResolver) {
            ((NameResolver) event.getBeanDefinition())
                    .resolveName(
```